### PR TITLE
ci: add PR checks and Dependabot auto-merge

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,31 @@
+name: checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # Builds the multi-stage image. This is the highest-value gate: it exercises the
+  # Dockerfile base-image bump and proves api/requirements.txt installs cleanly inside
+  # the image (the builder stage runs `pip install -r requirements.txt`).
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t filesync:ci .
+
+  # Installs the backend deps and imports the app modules, so a dependency bump that
+  # breaks an import is caught (a plain syntax check would miss runtime import errors).
+  # main.py refuses to import without SECRET_KEY, so pass a throwaway value.
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - run: pip install -r api/requirements.txt
+      - env:
+          SECRET_KEY: ci-not-a-real-secret
+        run: python -c "import api.main, api.signaling; print('import OK')"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+name: dependabot-automerge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Majors are left for human review; minor/patch merge once the
+    # required checks pass. Requires repo auto-merge enabled and a
+    # ruleset marking the checks as required — without required checks,
+    # --auto merges immediately.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+      - if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Sets up automatic merging of Dependabot **minor/patch** PRs, gated on real CI — mirroring the setup just added to the `fsend` repo.

Two new workflows:

### `checks.yml` (runs on every PR + push to main)
filesync had no CI running on PRs, so there was nothing for auto-merge to wait on. This adds:
- **`docker`** — builds the multi-stage image. Validates the Dockerfile base-image bump *and* that `api/requirements.txt` installs cleanly (the builder stage runs `pip install`).
- **`python`** — installs the backend deps and imports `api.main` / `api.signaling`, catching a dependency bump that breaks an import. (`main.py` requires `SECRET_KEY` at import, so a throwaway value is passed.)

### `dependabot-automerge.yml`
- Only acts on PRs authored by `dependabot[bot]` (the `if:` gate).
- Enables `--auto --squash` for **minor/patch** updates; **majors are excluded** for manual review.
- Auto-merge waits for the required checks before merging.

## Repo settings (applied separately, not in this PR)
- **Allow auto-merge** enabled on the repo.
- **Branch protection on `main`** requiring the `docker` and `python` checks (no approval required; admins can bypass).

Once merged, Dependabot minor/patch PRs will merge themselves once `docker` + `python` are green. Everything else (including other contributors' PRs) still requires a manual merge by you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)